### PR TITLE
refactor(ui): change imports of ui to root instead of parts of atomic

### DIFF
--- a/src/features/cards/organisms/card-item.js
+++ b/src/features/cards/organisms/card-item.js
@@ -5,7 +5,7 @@ import { format } from "date-fns"
 
 import { RichEditor } from "@lib/rich-text"
 import { Col, Row } from "@lib/styled-components-layout"
-import { Card, H3, Link, Button, ButtonPrimary } from "@ui/atoms"
+import { Card, H3, Link, Button, ButtonPrimary } from "@ui"
 
 export const CardItem = ({ onUsefulClick, card }) => (
   <CardBox>

--- a/src/features/cards/organisms/cards-list.js
+++ b/src/features/cards/organisms/cards-list.js
@@ -4,7 +4,7 @@ import { connect } from "react-redux"
 import styled from "styled-components"
 import { compose } from "recompose"
 
-import { ConditionalList } from "@ui/organisms"
+import { ConditionalList } from "@ui"
 import { cardsRegistrySelector } from "../selectors"
 import { setUsefulMark } from "../effects"
 

--- a/src/features/cards/pages/create.js
+++ b/src/features/cards/pages/create.js
@@ -9,7 +9,7 @@ import { compose, withProps } from "recompose"
 import { Col } from "@lib/styled-components-layout"
 import { RichEditor } from "@lib/rich-text"
 import { Authenticated } from "@features/common"
-import { Card, ButtonPrimary, Input } from "@ui/atoms"
+import { Card, ButtonPrimary, Input } from "@ui"
 
 import { CardsCommonTemplate } from "../templates/common"
 import { cardCreate } from "../effects"

--- a/src/features/cards/pages/view.js
+++ b/src/features/cards/pages/view.js
@@ -5,7 +5,7 @@ import { compose, lifecycle } from "recompose"
 import { format } from "date-fns"
 import { RichEditor } from "@lib/rich-text"
 import { Col } from "@lib/styled-components-layout"
-import { Card, H3, Text } from "@ui/atoms"
+import { Card, H3, Text } from "@ui"
 import { fetchFullCard } from "../effects"
 import { CardsCommonTemplate } from "../templates/common"
 import {

--- a/src/features/cards/templates/common.js
+++ b/src/features/cards/templates/common.js
@@ -2,9 +2,7 @@ import React from "react"
 import PropTypes from "prop-types"
 
 import { CommonContentTemplate } from "@features/common"
-import { FooterContent } from "@ui/atoms"
-import { Sidebar } from "@ui/molecules"
-import { Container, SidebarTemplate } from "@ui/templates"
+import { FooterContent, Sidebar, Container, SidebarTemplate } from "@ui"
 
 export const CardsCommonTemplate = ({ children, sidebar }) => (
   <CommonContentTemplate>

--- a/src/features/common/organisms/header.js
+++ b/src/features/common/organisms/header.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 import styled from "styled-components"
 import { Link } from "react-router-dom"
 import { ToggleThemeConsumer } from "@lib/theme-context"
-import { Container } from "@ui/templates"
+import { Container } from "@ui"
 import { WithAccount } from "./with-account"
 
 // https://codepen.io/anon/pen/PebeaL

--- a/src/features/common/pages/not-found.js
+++ b/src/features/common/pages/not-found.js
@@ -2,7 +2,7 @@ import React from "react"
 import styled from "styled-components"
 
 import { CommonContentTemplate } from "@features/common"
-import { Container } from "@ui/templates"
+import { Container } from "@ui"
 
 export const NotFoundPage = () => (
   <CommonContentTemplate>

--- a/src/features/join/pages/login.js
+++ b/src/features/join/pages/login.js
@@ -4,11 +4,19 @@ import { connect } from "react-redux"
 import { compose } from "recompose"
 import { withFormik } from "formik"
 
-import { Card, Input, H2, ButtonPrimary, Link, ErrorBox } from "@ui/atoms"
-import { PrimitiveFooter } from "@ui/organisms"
-import { Container, CenterContentTemplate } from "@ui/templates"
-import { Col, Row } from "@lib/styled-components-layout"
+import {
+  Card,
+  Input,
+  H2,
+  ButtonPrimary,
+  Link,
+  ErrorBox,
+  PrimitiveFooter,
+  Container,
+  CenterContentTemplate,
+} from "@ui"
 
+import { Col, Row } from "@lib/styled-components-layout"
 import { userLogin } from "../effects/join"
 
 const mapServerToClientError = (error) => {

--- a/src/features/users/organisms/error.js
+++ b/src/features/users/organisms/error.js
@@ -1,7 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-import { Card } from "@ui/atoms"
+import { Card } from "@ui"
 import { UsersCommonTemplate } from "../templates/common"
 
 const messageFromError = (fetching) => {

--- a/src/features/users/pages/user.js
+++ b/src/features/users/pages/user.js
@@ -4,7 +4,7 @@ import { fetchStatus } from "symbiote-fetching"
 import { compose, withPropsOnChange, branch, renderComponent } from "recompose"
 import { connect } from "react-redux"
 import { Col, Row } from "@lib/styled-components-layout"
-import { H3, H1 } from "@ui/atoms"
+import { H3, H1 } from "@ui"
 import { CardsList, CardItem } from "@features/cards"
 
 import { UsersCommonTemplate } from "../templates/common"

--- a/src/features/users/templates/common.js
+++ b/src/features/users/templates/common.js
@@ -2,9 +2,7 @@ import React from "react"
 import PropTypes from "prop-types"
 
 import { CommonContentTemplate } from "@features/common"
-import { FooterContent } from "@ui/atoms"
-import { Sidebar } from "@ui/molecules"
-import { Container, SidebarTemplate } from "@ui/templates"
+import { FooterContent, Sidebar, Container, SidebarTemplate } from "@ui"
 
 export const UsersCommonTemplate = ({ children, sidebar }) => (
   <CommonContentTemplate>

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -1,0 +1,33 @@
+//= ======TEMPLATES=======
+export { CenterContentTemplate } from "./templates/center-content"
+export { MainTemplate } from "./templates/main-template"
+export { SidebarTemplate } from "./templates/sidebar-template"
+export { Container } from "./templates/container" // move to atoms, but check imports
+
+//= ======ORGANISMS=======
+export { PrimitiveFooter } from "./organisms/primitive-footer"
+export { ItemsList } from "./organisms/items-list"
+export { ConditionalList } from "./organisms/conditional-list"
+
+//= ======MOLECTULES=======
+export { Sidebar } from "./molecules/sidebar"
+export { TextArea } from "./molecules/textarea"
+
+//= ======ATOMS=======
+// Typography
+export { H1, H2, H3 } from "./atoms/heading"
+export { Text } from "./atoms/text"
+
+// Containers & Boxes
+export { Card, CardSticky } from "./atoms/card"
+export { ErrorBox } from "./atoms/error-box"
+
+// UI (Btns, links)
+export { Button, ButtonPrimary } from "./atoms/button"
+export { Link } from "./atoms/link"
+
+// Form Elements
+export { Input } from "./atoms/input"
+
+// Why it's here?
+export { FooterContent } from "./atoms/footer-content"

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -1,33 +1,4 @@
-//= ======TEMPLATES=======
-export { CenterContentTemplate } from "./templates/center-content"
-export { MainTemplate } from "./templates/main-template"
-export { SidebarTemplate } from "./templates/sidebar-template"
-export { Container } from "./templates/container" // move to atoms, but check imports
-
-//= ======ORGANISMS=======
-export { PrimitiveFooter } from "./organisms/primitive-footer"
-export { ItemsList } from "./organisms/items-list"
-export { ConditionalList } from "./organisms/conditional-list"
-
-//= ======MOLECTULES=======
-export { Sidebar } from "./molecules/sidebar"
-export { TextArea } from "./molecules/textarea"
-
-//= ======ATOMS=======
-// Typography
-export { H1, H2, H3 } from "./atoms/heading"
-export { Text } from "./atoms/text"
-
-// Containers & Boxes
-export { Card, CardSticky } from "./atoms/card"
-export { ErrorBox } from "./atoms/error-box"
-
-// UI (Btns, links)
-export { Button, ButtonPrimary } from "./atoms/button"
-export { Link } from "./atoms/link"
-
-// Form Elements
-export { Input } from "./atoms/input"
-
-// Why it's here?
-export { FooterContent } from "./atoms/footer-content"
+export * from "./atoms"
+export * from "./molecules"
+export * from "./organisms"
+export * from "./templates"


### PR DESCRIPTION
Index.js with exports for atoms/molecules/templates in ui still exist, but I added index.js in root ui with all exports for ui components. In case of rearrange of ui structure we can keep feature components independent. 
Import in features with "@ui" for all components.